### PR TITLE
Fixed missing authentication credentials for second and further arguments of checkout command

### DIFF
--- a/src/Command/CheckoutCommand.php
+++ b/src/Command/CheckoutCommand.php
@@ -33,7 +33,7 @@ class CheckoutCommand extends BaseCommand
             $this->addRepository($composerPullRequestData->repositoryUrl, $output);
             $this->requireDependency($composerPullRequestData, $output, $preferSource);
         }
-
+        $this->resetComposer();
         $this->executePostInstallCommands($output);
 
         return 0;
@@ -51,9 +51,7 @@ class CheckoutCommand extends BaseCommand
 
         if ($configCommand->run($input, $output)) {
             throw new \RuntimeException('Something wrong happened when adding repository');
-        }
-
-        $this->resetComposer();
+        }        
     }
 
     private function extractDataFromPullRequest(GithubPullRequestData $pullRequestData): ComposerPullRequestData
@@ -69,7 +67,7 @@ class CheckoutCommand extends BaseCommand
             $this->getDownloader()
                     ->get($pullRequestDataRequestUrl)
                     ->getBody(),
-    true
+     true
         );
 
         $targetBranch = $pullRequestDetails['base']['ref'];


### PR DESCRIPTION
Moved https://github.com/mnocon/composer-checkout/blame/master/src/Command/CheckoutCommand.php#L56 call outside of the https://github.com/mnocon/composer-checkout/blame/master/src/Command/CheckoutCommand.php#L30 loop as  `\Composer\Command\BaseCommand::resetCompose`r clears authentication credentials which are never loaded again. See https://github.com/composer/composer/blob/aefa46dfbabea3497437480061496ba54773bf46/src/Composer/Console/Application.php#L533C15-L533C51 

Solves https://github.com/mnocon/composer-checkout/issues/2